### PR TITLE
Update TF2 rolling notes: AI context for 13 July agenda

### DIFF
--- a/meetings/tf2-rolling-notes.md
+++ b/meetings/tf2-rolling-notes.md
@@ -12,7 +12,7 @@ Repository: <https://github.com/EVERSE-ResearchSoftware/reference-framework>
 
 ## A. AI position
 
-No agreed EVERSE position on AI. Feeds Fotis's policy brief, due February 2027.
+No agreed EVERSE position on AI. Feeds Fotis's policy brief, due February 2027, and Guido's EU ESC (Brussels) talk — asked for messaging, not yet provided.
 
 ## B. Michael Sparks document
 
@@ -33,7 +33,7 @@ Hugo's prototypes (TeSS metadata agent, RSQKit chatbot) — blocked on compute a
 
 ## E. AI webinar
 
-Joint with ReSA (Michelle Barker), target October/November. Contact not yet made.
+Joint with ReSA — Carlos contacted Michelle Barker, awaiting outcome. Target early November, after the October industry survey webinar.
 
 ## F. RF section reviews
 


### PR DESCRIPTION
## Summary
- Item A: adds Guido's EU ESC (Brussels) talk as a driver for the AI position discussion
- Item E: corrects webinar contact status (Carlos already reached out to Michelle Barker) and refines timing (early November, after the October industry survey webinar)